### PR TITLE
Fix yml syntax errors, typos, pluralization and some definitions.

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,17 +1,52 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Sodipodi ("http://www.sodipodi.com/") -->
-<svg id="svg378" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="480" width="640" version="1" y="0" x="0" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
- <metadata id="metadata4604">
-  <rdf:RDF>
-   <cc:Work rdf:about="">
-  <dc:format>image/svg+xml</dc:format>
-  <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-   </cc:Work>
-  </rdf:RDF>
- </metadata>
- <g id="flag" fill-rule="evenodd" stroke-width="1pt" transform="scale(.60207 .67733)">
-  <rect id="rect171" height="708.66" width="1063" y="0" x="0" fill="#fff"/>
-  <rect id="rect403" height="708.66" width="354.33" y="0" x="0" fill="#005700"/>
-  <rect id="rect135" height="708.66" width="354.33" y="0" x="708.66" fill="#fc0000"/>
- </g>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="italian-flag"
+   height="480"
+   width="720"
+   version="1"
+   y="0"
+   x="0">
+  <metadata
+     id="meta">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="stroke:none"
+     id="flag"
+     fill-rule="evernodd">
+    <rect
+       fill="#ffffff"
+       id="white"
+       height="480"
+       width="720"
+       y="0"
+       x="0" />
+    <rect
+       fill="#005700"
+       id="green"
+       height="480"
+       width="240"
+       y="0"
+       x="0" />
+    <rect
+       fill="#fc0000"
+       id="red"
+       height="480"
+       width="240"
+       y="0"
+       x="480" />
+  </g>
 </svg>

--- a/locale/antoinefr-money.yml
+++ b/locale/antoinefr-money.yml
@@ -4,7 +4,7 @@ antoinefr-money:
       title: Impostazioni
       moneyforpost: Denaro dato per un nuovo post
       moneyfordiscussion: Denaro dato per una nuova discussione
-      moneyname: Nome del denaro (ex: punti)
+      moneyname: "Nome del denaro (ex: punti)"
     permissions:
       edit_money_label: Modifica denaro
   forum:
@@ -12,5 +12,5 @@ antoinefr-money:
       money_button: Modifica denaro
     modal:
       title: "Modifica il denaro di: {username}"
-      current: Attuale :
+      current: "Attuale :"
       submit_button: => core.ref.save_changes

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -354,7 +354,7 @@ core:
       notify_by_email_heading: => core.ref.email
       notify_by_web_heading: Web
       notify_discussion_renamed_label: Qualcuno ha modificato una discussione che ho iniziato
-      privacy_disclose_online_label: Permetti agli altri di vedere quanto sono online
+      privacy_disclose_online_label: Permetti agli altri di vedere quando sono online
       privacy_heading: Privacy
       title: => core.ref.settings
 

--- a/locale/flagrow-bazaar.yml
+++ b/locale/flagrow-bazaar.yml
@@ -6,13 +6,13 @@ flagrow-bazaar:
             title: Flagrow Bazaar
             field:
                 apiToken: API token
-                apiTokenDescription: API token è richiesto per accedere al Flagrow extension api. Se già impostato, sei pronto per iniziare!
+                apiTokenDescription: API token Ã¨ richiesto per accedere al Flagrow extension api. Se giÃ  impostato, sei pronto per iniziare!
         nav:
             title: Bazaar
             description: Il mercato delle estensioni.
         page:
             button:
-                more: Di più
+                more: Di piÃ¹
                 install: Installa
                 uninstall: Disinstalla
                 enable: Attiva

--- a/locale/flarum-approval.yml
+++ b/locale/flarum-approval.yml
@@ -9,7 +9,7 @@ flarum-approval:
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
-      approve_posts_label: Appriva messaggi
+      approve_posts_label: Approva messaggi
       reply_without_approval_label: Rispondi a discussioni senza l'approvazione
       start_discussions_without_approval_label: Inizia discussioni senza l'approvazione
 

--- a/locale/flarum-likes.yml
+++ b/locale/flarum-likes.yml
@@ -17,13 +17,13 @@ flarum-likes:
     # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
       others_text: => core.ref.some_others
-      post_liked_text: "{username} ha messaggio mi piace al tuo messaggio"  # Can be pluralized to agree with the number of users!
+      post_liked_text: "{username} ha messo mi piace al tuo messaggio"  # Can be pluralized to agree with the number of users!
 
     # These translations are displayed beneath individual posts.
     post:
       like_link: Mi piace
-      liked_by_self_text: "{users} ha messo mi piace."  # Can be pluralized to agree with the number of users!
-      liked_by_text: "{users} hanno messo mi piace.|{users} ha messo mi piace."
+      liked_by_self_text: "{users} hai messo mi piace.|{users} avete messo mi piace."  # Can be pluralized to agree with the number of users!
+      liked_by_text: "{users} ha messo mi piace.|{users} hanno messo mi piace."
       others_link: => core.ref.some_others
       unlike_link: Non mi piace
       you_text: => core.ref.you

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -19,7 +19,7 @@ flarum-mentions:
 
     # These translations are displayed beneath individual posts.
     post:
-      mentioned_by_self_text: "{users} ha risposto a questo messaggio|{users} hanno risposto a questo messaggio."  # Can be pluralized to agree with the number of users!
+      mentioned_by_self_text: "{users} hai risposto a questo messaggio|{users} avete risposto a questo messaggio."  # Can be pluralized to agree with the number of users!
       mentioned_by_text: "{users} ha risposto a questo messaggio|{users} hanno risposto a questo messaggio."       # Can be pluralized to agree with the number of users!
       others_text: => core.ref.some_others
       quote_button: Cita

--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -24,7 +24,7 @@ flarum-subscriptions:
 
     # These translations are used by the Notifications dropdown, a.k.a. "the bell".
     notifications:
-      new_post_text: "{username} posted"
+      new_post_text: "{username} ha scritto"
 
     # These translations are used in the Settings page.
     settings:

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -48,9 +48,9 @@ flarum-tags:
     tags:
       about_tags_text: "Le etichette vengono usate per categorizzare le discussioni. Le etichette primarie sono come le categorie tradizionali dei forum: possono essere disposte in una gerarchia a due livelli. Le etichette secondarie non hanno gerarchia o ordine, e sono utili per miccro-categorizzare."
       create_tag_button: => flarum-tags.ref.create_tag
-      primary_heading: Primary Tags
-      secondary_heading: Secondary Tags
-      settings_button: Settings
+      primary_heading: Etichette Primarie
+      secondary_heading: Etichette Secondarie
+      settings_button: Impostazioni
 
   # Translations in this namespace are used by the forum user interface.
   forum:

--- a/locale/issyrocks12-twofactor.yml
+++ b/locale/issyrocks12-twofactor.yml
@@ -2,7 +2,7 @@ issyrocks12-twofactor:
   forum:
     accountlabel: Two Factor
     reloadmsg: Preparazione two factor... riapri il modale di Two Factor.
-    incorrect_2fa: Il codice inserito è errato
+    incorrect_2fa: Il codice inserito Ã¨ errato
     2fa_disabled: Autenticazione a due fattori disattivato con successo.
     2fa_enabled: Autenticazione a due fattori attivato con successo.
     remember_me_label: Ricordami

--- a/locale/wiseclock-post-copyright.yml
+++ b/locale/wiseclock-post-copyright.yml
@@ -32,5 +32,5 @@ wiseclock-post-copyright:
         prohibited: Ripubblicazione non consentito
       addition:
         title: Opzioni aggiuntive
-        help: "Aggiungi le opzioni che desideri utilizzando il formato <code>key,menu,ui</code> separati da un apostrofo. Ogni linea rappresenta una opzione. KEY è ID univoco di un opzione; MENU è la stringa visualizzata nell elenco a discesa; UI è la stringa inferiore di ogni post. Una linea valida deve essere simile a questa:"
+        help: "Aggiungi le opzioni che desideri utilizzando il formato <code>key,menu,ui</code> separati da un apostrofo. Ogni linea rappresenta una opzione. KEY Ã¨ ID univoco di un opzione; MENU Ã¨ la stringa visualizzata nell elenco a discesa; UI Ã¨ la stringa inferiore di ogni post. Una linea valida deve essere simile a questa:"
         notes: "Sei vuoi utilizzare una virgola nella stringa, assicurati di usare questo modo: <code>\\,</code>."


### PR DESCRIPTION
I found errors while doing some syntax checking with
ruby -e "require 'yaml';puts YAML.load_file('filename.yml')"

Fix "mapping values are not allowed in this context" by using double quotes.
and "invalid trailing UTF-8 octet" by using àèìòù characters in the right way.

Fixed some pluralized definitions.
Fixed some typo.

Translated new definitions.